### PR TITLE
Reimplement second order low pass filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ add_library(filter
   src/filter.h
   src/iir.h
   src/iir.cpp
+  src/lpf2p.h
+  src/lpf2p.cpp
 )
 # Link libraries
 target_link_libraries(filter

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 # Project information
 project(Filter
-  VERSION 4.0.0
+  VERSION 4.0.1
   DESCRIPTION "Digital filter library."
   LANGUAGES CXX
 )
@@ -62,13 +62,22 @@ target_include_directories(filter PUBLIC
 if (PROJECT_NAME STREQUAL CMAKE_PROJECT_NAME)
   # Add the example target
   add_executable(filter_example examples/cmake/filter_example.cc)
+  add_executable(lpf2p_example examples/cmake/lpf2p_example.cpp)
   # Add the includes
   target_include_directories(filter_example PUBLIC 
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
+  target_include_directories(lpf2p_example PUBLIC 
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
   # Link libraries to the test target
   target_link_libraries(filter_example
+    PRIVATE 
+      filter
+  )
+  target_link_libraries(lpf2p_example
     PRIVATE 
       filter
   )

--- a/examples/cmake/lpf2p_example.cpp
+++ b/examples/cmake/lpf2p_example.cpp
@@ -23,37 +23,50 @@
 * IN THE SOFTWARE.
 */
 
-#ifndef FILTER_SRC_LPF2P_H_  // NOLINT
-#define FILTER_SRC_LPF2P_H_
+#include "filter.h"
+#include <array>
+#include <iostream>
 
-#if defined(ARDUINO)
-#include <Arduino.h>
-#else
-#include <cmath>
-#include <cstddef>
-#include <cstdint>
-#endif
+int main() {
+    float x[] = {
+    1,
+    1.5,
+    1,
+    0.5,
+    -0.1,
+    0.1,
+    5,
+    5.1,
+    };
 
-namespace bfs {
+    float cutoff_hz = 5.0f;
+    float samp_hz = 100.0f;
 
-template<typename T>
-class Lpf2p {
- public:
-  void Init(const T cutoff_hz, const T samp_hz);
-  void Init(const T cutoff_hz, const T samp_hz,
-            const T initial_val);
-  T Filter(const T val, const T cutoff_hz=static_cast<T>(0), 
-            const T samp_hz=static_cast<T>(0));
+    /*
+    First implementation follows BFS with separate init and filter method
+    */
+    bfs::Lpf2p<float> lpf2p_bfs;
 
- private:
-  bool initialized_ = false;
-  T a1_, a2_, b0_, b1_, b2_;
-  T cutoff_hz_, ret_val_;
-  T prev_output_ = static_cast<T>(0);
-  T delay1_ = prev_output_;
-  T delay2_ = prev_output_;
-};
+    std::cout<<"Second implementation\n";
 
-}  // namespace bfs
+    // Init
+    lpf2p_bfs.Init(cutoff_hz, samp_hz, x[0]);
+    std::cout<<x[0]<<"\n"; // This method skip the first val in the loop
 
-#endif  // FILTER_SRC_LPF2P_H_ NOLINT
+    // Apply filter
+    for (size_t i = 1; i < (sizeof(x) / sizeof(x[0])); i++){
+        float y = lpf2p_bfs.Filter(x[i]);
+        std::cout<<y<<"\n";
+    }
+
+    /*
+    Second implementation follows Ardupilot by just using the filter method
+    */
+
+    bfs::Lpf2p<float> lpf2p_ardu;
+    std::cout<<"Second implementation\n";
+    for (size_t i = 0; i < (sizeof(x) / sizeof(x[0])); i++){
+        float y = lpf2p_ardu.Filter(x[i], cutoff_hz, samp_hz);
+        std::cout<<y<<"\n";
+    }
+}

--- a/src/filter.h
+++ b/src/filter.h
@@ -35,6 +35,7 @@
 #endif
 
 #include "iir.h"  // NOLINT
+#include "lpf2p.h" //NOLINT
 
 namespace bfs {
 

--- a/src/lpf2p.cpp
+++ b/src/lpf2p.cpp
@@ -57,6 +57,7 @@ void Lpf2p<T>::Init(const T cutoff_hz, const T samp_hz, const T initial_val) {
     Init(cutoff_hz, samp_hz); //Calculate the necessary filter coefficients
 
     prev_output_ = delay1_ = delay2_ = initial_val * (static_cast<T>(1) / (static_cast<T>(1) + a1_ + a2_));
+    
 }
 
 template<typename T>
@@ -75,3 +76,7 @@ T Lpf2p<T>::Filter(const T val, const T cutoff_hz, const T samp_hz) {
 
 
 }   //namespace bfs
+
+// Make instances so we don't have to implement this in header
+template class bfs::Lpf2p<float>;
+template class bfs::Lpf2p<double>;

--- a/src/lpf2p.cpp
+++ b/src/lpf2p.cpp
@@ -1,0 +1,77 @@
+/*
+* Tuan D Luong
+* tdluong@crimson.ua.edu
+* 
+*
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the “Software”), to
+* deal in the Software without restriction, including without limitation the
+* rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+* sell copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+* IN THE SOFTWARE.
+*/
+
+#if defined(ARDUINO)
+#include <Arduino.h>
+#else
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#endif
+
+#include "lpf2p.h"  // NOLINT
+#include "units.h"  // NOLINT
+#include <algorithm>
+
+
+namespace bfs {
+template<typename T> 
+void Lpf2p<T>::Init(const T cutoff_hz, const T samp_hz) {
+    cutoff_hz_ = std::min(cutoff_hz, samp_hz * static_cast<T>(0.4)); // Keep cutoff freq below Nyquist
+    T fr = samp_hz / cutoff_hz_;
+    T ohm = std::tan(static_cast<T>(BFS_PI_DOUBLE) / fr);
+    T c = static_cast<T>(1) + static_cast<T>(2) * std::cos(static_cast<T>(BFS_PI_DOUBLE)/ static_cast<T>(4)) * ohm + ohm * ohm;
+    b0_ = ohm * ohm / c;
+    b1_ = static_cast<T>(2) * b0_;
+    b2_ = b0_;
+    
+    a1_ = static_cast<T>(2) * (ohm * ohm - static_cast<T>(1)) / c;
+    a2_ = (static_cast<T>(1) - static_cast<T>(2) * std::cos(static_cast<T>(BFS_PI_DOUBLE)/ static_cast<T>(4)) * ohm + ohm * ohm) / c;
+    initialized_ = true;
+}
+
+template<typename T>
+void Lpf2p<T>::Init(const T cutoff_hz, const T samp_hz, const T initial_val) {
+    Init(cutoff_hz, samp_hz); //Calculate the necessary filter coefficients
+
+    prev_output_ = delay1_ = delay2_ = initial_val * (static_cast<T>(1) / (static_cast<T>(1) + a1_ + a2_));
+}
+
+template<typename T>
+T Lpf2p<T>::Filter(const T val, const T cutoff_hz, const T samp_hz) {
+    if (!initialized_){
+        Init(cutoff_hz, samp_hz, val);
+    }
+
+    T ret;
+    prev_output_ = val - delay1_ * a1_ - delay2_ * a2_;
+    ret = prev_output_ * b0_ + delay1_ * b1_ + delay2_ * b2_;
+    delay2_ = delay1_;
+    delay1_ = prev_output_;
+    return ret;
+}
+
+
+}   //namespace bfs

--- a/src/lpf2p.h
+++ b/src/lpf2p.h
@@ -1,0 +1,58 @@
+/*
+* Tuan D Luong
+* tdluong@crimson.ua.edu
+* 
+*
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the “Software”), to
+* deal in the Software without restriction, including without limitation the
+* rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+* sell copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+* IN THE SOFTWARE.
+*/
+
+#ifndef FILTER_SRC_LPF2P_H_  // NOLINT
+#define FILTER_SRC_LPF2P_H_
+
+#if defined(ARDUINO)
+#include <Arduino.h>
+#else
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#endif
+
+namespace bfs {
+
+template<typename T>
+class Lpf2p {
+ public:
+  void Init(const T cutoff_hz, const T samp_hz);
+  void Init(const T cutoff_hz, const T samp_hz,
+            const T initial_val);
+  T Filter(const T val, const T cutoff_hz=static_cast<T>(0), const T samp_hz=static_cast<T>(0));
+
+ private:
+  bool initialized_ = false;
+  T a1_, a2_, b0_, b1_, b2_;
+  T cutoff_hz_, ret_val_;
+  T prev_output_ = static_cast<T>(0);
+  T delay1_ = prev_output_;
+  T delay2_ = prev_output_;
+};
+
+}  // namespace bfs
+
+#endif  // FILTER_SRC_LPF2P_H_ NOLINT

--- a/tests/filter_test.cc
+++ b/tests/filter_test.cc
@@ -240,13 +240,86 @@ TEST(Filter, MovingWindow) {
   /* Test filter */
   for (size_t i = 0; i < (sizeof(x) / sizeof(x[0])); i++) {
     float y = dlpf.Update(x[i]);
-    EXPECT_FLOAT_EQ(y, z[i]);
+    EXPECT_NEAR(y, z[i], 0.000001f);
   }
   /* Reset filter */
   dlpf.Reset();
   /* Test again */
   for (size_t i = 0; i < (sizeof(x) / sizeof(x[0])); i++) {
     float y = dlpf.Update(x[i]);
-    EXPECT_FLOAT_EQ(y, z[i]);
+    EXPECT_NEAR(y, z[i], 0.000001f);
+  }
+}
+
+TEST(Filter, LPF2P_IMP) {
+  // Result from Ardupilot LPF2P
+  float z[] = {
+    1,
+    1.010042,
+    1.035759,
+    1.049380,
+    1.011974,
+    0.9147217,
+    0.8812911,
+    1.094320
+  };
+
+  float x[] = {
+    1,
+    1.5,
+    1,
+    0.5,
+    -0.1,
+    0.1,
+    5,
+    5.1,
+  };
+
+  float cutoff_hz = 5.0f;
+  float samp_hz = 100.0f;
+
+  // Test implicit initialization
+  bfs::Lpf2p<float> lpf2p;
+  
+  for (size_t i = 0; i < (sizeof(x) / sizeof(x[0])); i++){
+    float y = lpf2p.Filter(x[i], cutoff_hz, samp_hz);
+    EXPECT_NEAR(y, z[i], 0.000001f);
+  }
+}
+
+TEST(Filter, LPF2P_ONESTEP_EXP) {
+  // Result from Ardupilot LPF2P
+  float z[] = {
+    1,
+    1.010042,
+    1.035759,
+    1.049380,
+    1.011974,
+    0.9147217,
+    0.8812911,
+    1.094320
+  };
+
+  float x[] = {
+    1,
+    1.5,
+    1,
+    0.5,
+    -0.1,
+    0.1,
+    5,
+    5.1,
+  };
+
+  float cutoff_hz = 5.0f;
+  float samp_hz = 100.0f;
+
+  // Test explicit one step initialization
+  bfs::Lpf2p<float> lpf2p;
+  lpf2p.Init(cutoff_hz, samp_hz, x[0]);
+
+  for (size_t i = 1; i < (sizeof(x) / sizeof(x[0])); i++){
+    float y = lpf2p.Filter(x[i]);
+    EXPECT_NEAR(y, z[i], 0.000001f);
   }
 }


### PR DESCRIPTION
Implement second order LPF again. This time, it is split into header and source files similar to IIR while still implemented as template class. 

Add different methods to use the filter, more details in the example file:

1. Separate init / filter method matching with how SPAARO is setup
2. Combined where only filter method is used. Initialization is done under the hood. This is similar to Ardupilot.

Also included unit test with values obtained from Ardupilot's implementation of LPF2P and example code for implementation.